### PR TITLE
feat(SpdrQueryBuilder): split params by type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sonicfury/spider-query-builder",
   "description": "Offers typing and query params building for API Platform",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": {
     "name": "Théo LAMBERT",
     "email": "theo.lambert@viacesi.fr"

--- a/src/spdrQueryBuilder.ts
+++ b/src/spdrQueryBuilder.ts
@@ -7,7 +7,7 @@ import {
     SpdrPageIdx,
     SpdrPageOperator,
     SpdrPageSize,
-    SpdrPagination,
+    SpdrPagination, SpdrParam,
     SpdrParamInterface,
     SpdrRange,
     SpdrRangeOperator,
@@ -19,64 +19,159 @@ export class SpdrQueryBuilder {
     private static readonly _DEFAULT_OPERAND = '&';
     private _query: string;
     private _operand: string;
-    private _firstOperand: string;
+    private _history: string[] = [];
+
+    private _params: SpdrParamInterface[] = [];
+    private _sortParams: SpdrParamInterface[] = [];
+    private _paginationParams: SpdrParamInterface[] = [];
 
     constructor(operand?: string) {
         this._query = '';
         this._operand = operand ?? SpdrQueryBuilder._DEFAULT_OPERAND;
-        operand && (this._firstOperand = operand);
     }
 
-    public append(param: SpdrParamInterface, operand: string = this._operand) {
-        this._query += `${operand}${param.query}`;
+    public operand(value: string): SpdrQueryBuilder {
+        this._operand = value;
+
+        return this;
+    }
+    
+    public clearHistory(): SpdrQueryBuilder {
+        this._history = [];
+
+        return this;
     }
 
     public search(property: string, values: string[], operand: string = this._operand): SpdrQueryBuilder {
-        this.append(new SpdrSearch(property, values, operand));
+        this._addParam(new SpdrSearch(property, values, operand));
 
         return this;
     }
 
     public exists(property: string, value: boolean = true): SpdrQueryBuilder {
-        this.append(new SpdrExists(property, value));
+        this._addParam(new SpdrExists(property, value));
 
         return this;
     }
 
     public range(property: string, operator: SpdrRangeOperator, value: number, secondValue?: number): SpdrQueryBuilder {
-        this.append(new SpdrRange(property, operator, value, secondValue));
+        this._addParam(new SpdrRange(property, operator, value, secondValue));
 
         return this;
     }
 
     public date(property: string, operator: SpdrDateOperator, value: Date): SpdrQueryBuilder {
-        this.append(new SpdrDate(property, operator, value));
+        this._addParam(new SpdrDate(property, operator, value));
 
         return this;
     }
 
     public order(property: string, direction: SpdrOrderOperator): SpdrQueryBuilder {
-        this.append(new SpdrOrder(property, direction));
+        this._addSortParam(new SpdrOrder(property, direction));
 
         return this;
     }
 
-    public pagination(value: boolean = true, property: string = SpdrPageOperator.pagination): SpdrQueryBuilder {
-        this.append(new SpdrPagination(value, property));
+    public enablePagination(value: boolean = true, property: string = SpdrPageOperator.pagination): SpdrQueryBuilder {
+        this._addPaginationParam(new SpdrPagination(value, property));
 
         return this;
     }
 
     public pageIndex(value: number, property: string = SpdrPageOperator.page): SpdrQueryBuilder {
-        this.append(new SpdrPageIdx(value, property));
+        this._addPaginationParam(new SpdrPageIdx(value, property));
 
         return this;
     }
 
     public pageSize(value: number, property: string = SpdrPageOperator.itemsPerPage): SpdrQueryBuilder {
-        this.append(new SpdrPageSize(value, property));
+        this._addPaginationParam(new SpdrPageSize(value, property));
 
         return this;
+    }
+
+    /**
+     * Clears the query builder according to the type passed
+     * Clears completely if no type is passed
+     *
+     * @param type
+     */
+    public clear(type?: SpdrParamType): SpdrQueryBuilder {
+        switch (type) {
+            case SpdrParamType.param:
+                this._params = [];
+                break;
+            case SpdrParamType.sort:
+                this._sortParams = [];
+                break;
+            case SpdrParamType.pagination:
+                this._paginationParams = [];
+                break;
+            default:
+                this._params = [];
+                this._sortParams = [];
+                this._paginationParams = [];
+                break;
+        }
+
+        this._history.push(this.query);
+        this._buildQuery();
+
+        return this;
+    }
+
+    /**
+     * Removes all params of the passed type matching the passed property from the query builder
+     * If no type is passed, all params matching the passed property will be removed
+     *
+     * @param property
+     * @param type
+     */
+    public remove(property: string, type?: SpdrParamType): SpdrQueryBuilder {
+        switch (type) {
+            case SpdrParamType.param:
+                this._params = this._params.filter((param: SpdrParam) => param.property !== property);
+                break;
+            case SpdrParamType.sort:
+                this._sortParams = this._sortParams.filter((param: SpdrParam) => param.property !== property);
+                break;
+            case SpdrParamType.pagination:
+                this._paginationParams = this._paginationParams.filter((param: SpdrParam) => param.property !== property);
+                break;
+            default:
+                this._params = this._params.filter((param: SpdrParam) => param.property !== property);
+                this._sortParams = this._sortParams.filter((param: SpdrParam) => param.property !== property);
+                this._paginationParams = this._paginationParams.filter((param: SpdrParam) => param.property !== property);
+                break;
+        }
+
+        this._buildQuery();
+
+        return this;
+    }
+
+    private _addParam(param: SpdrParamInterface) {
+        this._params.push(param);
+        this._buildQuery();
+    }
+
+    private _addSortParam(param: SpdrParamInterface) {
+        this._sortParams.push(param);
+        this._buildQuery();
+    }
+
+    private _addPaginationParam(param: SpdrParamInterface) {
+        this._paginationParams.push(param);
+        this._buildQuery();
+    }
+
+    private _append(param: SpdrParamInterface, operand: string = this._operand) {
+        this._query += `${operand}${param.query}`;
+    }
+
+    private _buildQuery() {
+        this._query = '';
+        [...this._params, ...this._sortParams, ...this._paginationParams].forEach(param => this._append(param));
     }
 
     /**
@@ -84,24 +179,18 @@ export class SpdrQueryBuilder {
      * The query will be empty if you didn't feed the builder with params.
      */
     get query(): string {
-        return this._query.slice(this._firstOperand ? this._firstOperand.length : this._operand.length);
+        return this._query.slice(this._operand.length);
     }
 
-    /**
-     * Returns the operand used in the query building.
-     */
-    get operand(): string {
-        return this._operand;
+    get history(): string[] {
+        return this._history;
     }
 
-    /**
-     * Sets the operand used in the query building.
-     * @param value
-     */
-    setOperand(value: string): SpdrQueryBuilder {
-        this._operand = value;
-        !this._firstOperand && (this._firstOperand = value);
-
-        return this;
+    get previousQuery(): string {
+        return this._history[this._history.length - 1];
     }
+}
+
+export enum SpdrParamType {
+    param, sort, pagination
 }

--- a/test/spdrQueryBuilder.spec.ts
+++ b/test/spdrQueryBuilder.spec.ts
@@ -1,10 +1,6 @@
 import * as chai from 'chai';
-import {
-    SpdrDateOperator,
-    SpdrQueryBuilder,
-    SpdrRangeOperator,
-    SpdrOrderOperator
-} from "../src";
+import {SpdrDateOperator, SpdrOrderOperator, SpdrQueryBuilder, SpdrRangeOperator} from "../src";
+import {SpdrParamType} from "../src/spdrQueryBuilder";
 
 chai.should();
 
@@ -27,6 +23,7 @@ describe('Testing SpdrQueryBuilder', () => {
 
             qb.query.should.equal(expectedQuery);
         });
+
     it('should append "order[name]=asc" to "name=John Doe"', () => {
 
         const qb = new SpdrQueryBuilder()
@@ -40,7 +37,7 @@ describe('Testing SpdrQueryBuilder', () => {
         qb.query.should.equal('name=John Doe&order[name]=asc');
     });
 
-    it('should build a query equal to exists[isActive]=true&&name[]=John Doe&&name[]=Jane Doe', () => {
+    it('should build with operand setting a query equal to exists[isActive]=true&&name[]=John Doe&&name[]=Jane Doe', () => {
 
         const qb = new SpdrQueryBuilder('&&')
 
@@ -53,12 +50,12 @@ describe('Testing SpdrQueryBuilder', () => {
         qb.query.should.equal(expectedQuery);
     });
 
-    it('should build a query equal to exists[isActive]=true&&name[]=John Doe&&name[]=Jane Doe', () => {
+    it('should build with operand setting a query equal to exists[isActive]=true&&name[]=John Doe&&name[]=Jane Doe', () => {
 
         const qb = new SpdrQueryBuilder()
 
         qb
-            .setOperand('&&')
+            .operand('&&')
             .exists('isActive', true)
             .search('name', ['John Doe', 'Jane Doe'])
 
@@ -67,12 +64,12 @@ describe('Testing SpdrQueryBuilder', () => {
         qb.query.should.equal(expectedQuery);
     });
 
-    it('should build a query equal to exists[isActive]=true&&name[]=John Doe||name[]=Jane Doe', () => {
+    it('should build with search operand setting a query equal to exists[isActive]=true&&name[]=John Doe||name[]=Jane Doe', () => {
 
         const qb = new SpdrQueryBuilder()
 
         qb
-            .setOperand('&&')
+            .operand('&&')
             .exists('isActive', true)
             .search('name', ['John Doe', 'Jane Doe'], '||')
 
@@ -81,19 +78,168 @@ describe('Testing SpdrQueryBuilder', () => {
         qb.query.should.equal(expectedQuery);
     });
 
-    it('should build a query equal to exists[isActive]=true&&name=John Doe!!addedAt[strictly_before]=${isoString}&orders[between]=0..10', () => {
+    it('should build with operand switching a query equal to exists[isActive]=true&name=John Doe&addedAt[strictly_before]=${isoString}&orders[between]=0..10', () => {
         const qb = new SpdrQueryBuilder('&&')
 
         qb
             .exists('isActive', true)
             .search('name', ['John Doe'])
-            .setOperand('!!')
+            .operand('!!')
             .date('addedAt', SpdrDateOperator.strictlyBefore, date)
-            .setOperand('&')
+            .operand('&')
             .range('orders', SpdrRangeOperator.between, 0, 10)
 
-        const expectedQuery = `exists[isActive]=true&&name=John Doe!!addedAt[strictly_before]=${isoString}&orders[between]=0..10`;
+        const expectedQuery = `exists[isActive]=true&name=John Doe&addedAt[strictly_before]=${isoString}&orders[between]=0..10`;
 
         qb.query.should.equal(expectedQuery);
+    });
+
+    it('should build a query and change only the sort params', () => {
+            const expectedQuery = `exists[isActive]=true&name[]=John Doe&name[]=Jane Doe&addedAt[strictly_before]=${isoString}&orders[between]=0..10&order[lastname]=desc&_page=2&itemsPerPage=10`;
+
+            const qb = new SpdrQueryBuilder()
+                .exists('isActive', true)
+                .search('name', ['John Doe', 'Jane Doe'])
+                .date('addedAt', SpdrDateOperator.strictlyBefore, date)
+                .range('orders', SpdrRangeOperator.between, 0, 10)
+                .order('name', SpdrOrderOperator.asc)
+                .pageIndex(2, '_page')
+                .pageSize(10)
+                .clear(SpdrParamType.sort)
+                .order('lastname', SpdrOrderOperator.desc)
+
+            qb.query.should.equal(expectedQuery);
+        });
+
+    it('should build a query and change only the pagination params', () => {
+        const expectedQuery = `exists[isActive]=true&name[]=John Doe&name[]=Jane Doe&addedAt[strictly_before]=${isoString}&orders[between]=0..10&order[name]=asc&pagination=true&_page=3&itemsPerPage=20`;
+
+        const qb = new SpdrQueryBuilder()
+            .exists('isActive', true)
+            .search('name', ['John Doe', 'Jane Doe'])
+            .date('addedAt', SpdrDateOperator.strictlyBefore, date)
+            .range('orders', SpdrRangeOperator.between, 0, 10)
+            .order('name', SpdrOrderOperator.asc)
+            .pageIndex(2, '_page')
+            .pageSize(10)
+            .clear(SpdrParamType.pagination)
+            .enablePagination()
+            .pageIndex(3, '_page')
+            .pageSize(20)
+
+        qb.query.should.equal(expectedQuery);
+    });
+
+    it('should build a query and change only other params (not pagination nor sort)', () => {
+        const expectedQuery = `exists[isActive]=true&order[name]=asc&_page=2&itemsPerPage=10`;
+
+        const qb = new SpdrQueryBuilder()
+            .exists('isActive', true)
+            .search('name', ['John Doe', 'Jane Doe'])
+            .date('addedAt', SpdrDateOperator.strictlyBefore, date)
+            .range('orders', SpdrRangeOperator.between, 0, 10)
+            .order('name', SpdrOrderOperator.asc)
+            .pageIndex(2, '_page')
+            .pageSize(10)
+            .clear(SpdrParamType.param)
+            .exists('isActive')
+
+        qb.query.should.equal(expectedQuery);
+    });
+
+    it('should build a query and clear it completely', () => {
+        const expectedQuery = ``;
+
+        const qb = new SpdrQueryBuilder()
+            .exists('isActive', true)
+            .search('name', ['John Doe', 'Jane Doe'])
+            .date('addedAt', SpdrDateOperator.strictlyBefore, date)
+            .range('orders', SpdrRangeOperator.between, 0, 10)
+            .order('name', SpdrOrderOperator.asc)
+            .pageIndex(2, '_page')
+            .pageSize(10)
+            .clear()
+
+        qb.query.should.equal(expectedQuery);
+    });
+
+    it('should build a query and remove only the search on the name', () => {
+        const expectedQuery = `exists[isActive]=true&addedAt[strictly_before]=${isoString}&orders[between]=0..10&order[name]=asc&_page=2&itemsPerPage=10`;
+
+        const qb = new SpdrQueryBuilder()
+            .exists('isActive', true)
+            .search('name', ['John Doe', 'Jane Doe'])
+            .date('addedAt', SpdrDateOperator.strictlyBefore, date)
+            .range('orders', SpdrRangeOperator.between, 0, 10)
+            .order('name', SpdrOrderOperator.asc)
+            .pageIndex(2, '_page')
+            .pageSize(10);
+
+        qb.remove('name', SpdrParamType.param);
+
+        qb.query.should.equal(expectedQuery);
+    });
+
+    it('should build a query and remove the search on the name and the order filter on the name too', () => {
+        const expectedQuery = `exists[isActive]=true&addedAt[strictly_before]=${isoString}&orders[between]=0..10&_page=2&itemsPerPage=10`;
+
+        const qb = new SpdrQueryBuilder()
+            .exists('isActive', true)
+            .search('name', ['John Doe', 'Jane Doe'])
+            .date('addedAt', SpdrDateOperator.strictlyBefore, date)
+            .range('orders', SpdrRangeOperator.between, 0, 10)
+            .order('name', SpdrOrderOperator.asc)
+            .pageIndex(2, '_page')
+            .pageSize(10);
+
+        qb.remove('name');
+
+        qb.query.should.equal(expectedQuery);
+    });
+
+    it('should build 3 queries with the same instance and retrieve them in the history', () => {
+        const expectedQuery1 = `exists[isActive]=true&name[]=John Doe&name[]=Jane Doe`;
+        const expectedQuery2 = `name[]=John Doe&name[]=Jane Doe&addedAt[strictly_before]=${isoString}`;
+        const expectedQuery3 = `name[]=John Doe&name[]=Jane Doe&addedAt[strictly_before]=${isoString}&orders[between]=0..10`;
+
+        const qb = new SpdrQueryBuilder()
+            .exists('isActive', true)
+            .search('name', ['John Doe', 'Jane Doe'])
+
+        qb.query.should.equal(expectedQuery1);
+
+        qb
+            .clear()
+            .search('name', ['John Doe', 'Jane Doe'])
+            .date('addedAt', SpdrDateOperator.strictlyBefore, date)
+
+        qb.query.should.equal(expectedQuery2);
+        qb.previousQuery.should.equal(expectedQuery1);
+
+        qb.clear()
+            .search('name', ['John Doe', 'Jane Doe'])
+            .date('addedAt', SpdrDateOperator.strictlyBefore, date)
+            .range('orders', SpdrRangeOperator.between, 0, 10)
+
+        qb.query.should.equal(expectedQuery3);
+        qb.history.should.deep.equal([expectedQuery1, expectedQuery2]);
+    });
+
+    it('should build 3 queries with the same instance, and clear the history', () => {
+        const expectedQuery = `name[]=John Doe&name[]=Jane Doe&addedAt[strictly_before]=${isoString}&orders[between]=0..10`;
+
+        const qb = new SpdrQueryBuilder()
+            .exists('isActive', true)
+            .search('name', ['John Doe', 'Jane Doe'])
+            .clear()
+            .search('name', ['John Doe', 'Jane Doe'])
+            .date('addedAt', SpdrDateOperator.strictlyBefore, date).clear()
+            .search('name', ['John Doe', 'Jane Doe'])
+            .date('addedAt', SpdrDateOperator.strictlyBefore, date)
+            .range('orders', SpdrRangeOperator.between, 0, 10)
+            .clearHistory();
+
+        qb.query.should.equal(expectedQuery);
+        qb.history.should.deep.equal([]);
     });
 })


### PR DESCRIPTION
- split params in 3 types: params, sort, and pagination
- added history
- added clear and remove methods
- made append method private
- renamed pagination method
- refactored operand handling
- updated docs

BREAKING CHANGE: SpdrQueryBuilder.pagination() is now SpdrQueryBuilder.enablePagination()
BREAKING CHANGE: SpdrQueryBuilder.append(param) is no longer available for now
BREAKING CHANGE: SpdrQueryBuilder.setOperand(value) is now SpdrQueryBuilder.operand(value) and behaviour has slightly changed, see docs